### PR TITLE
Remove I/O from reshape_fields function

### DIFF
--- a/utils/data_loader_multifiles.py
+++ b/utils/data_loader_multifiles.py
@@ -95,6 +95,10 @@ class GetDataset(Dataset):
     self.orography = params.orography
     self.precip = True if "precip" in params else False
     self.add_noise = params.add_noise if train else False
+    self.in_means = np.load(params.global_means_path)[:, self.in_channels]
+    self.in_stds = np.load(params.global_stds_path)[:, self.in_channels]
+    self.out_means = np.load(params.global_means_path)[:, self.out_channels]
+    self.out_stds = np.load(params.global_stds_path)[:, self.out_channels]
 
     if self.precip:
         path = params.precip+'/train' if train else params.precip+'/test'
@@ -197,15 +201,15 @@ class GetDataset(Dataset):
       rnd_y = 0
       
     if self.precip:
-      return reshape_fields(self.files[year_idx][inp_local_idx, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train), \
+      return reshape_fields(self.files[year_idx][inp_local_idx, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train, self.in_means, self.in_stds), \
                 reshape_precip(self.precip_files[year_idx][tar_local_idx+step], 'tar', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y, self.params, y_roll, self.train)
     else:
         if self.two_step_training:
-            return reshape_fields(self.files[year_idx][(local_idx-self.dt*self.n_history):(local_idx+1):self.dt, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train, self.normalize, orog, self.add_noise), \
-                    reshape_fields(self.files[year_idx][local_idx + step:local_idx + step + 2, self.out_channels], 'tar', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y, self.params, y_roll, self.train, self.normalize, orog)
+            return reshape_fields(self.files[year_idx][(local_idx-self.dt*self.n_history):(local_idx+1):self.dt, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train, self.in_means, self.in_stds, self.normalize, orog, self.add_noise), \
+                    reshape_fields(self.files[year_idx][local_idx + step:local_idx + step + 2, self.out_channels], 'tar', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y, self.params, y_roll, self.train, self.out_means, self.out_stds, self.normalize, orog)
         else:
-            return reshape_fields(self.files[year_idx][(local_idx-self.dt*self.n_history):(local_idx+1):self.dt, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train, self.normalize, orog, self.add_noise), \
-                    reshape_fields(self.files[year_idx][local_idx + step, self.out_channels], 'tar', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y, self.params, y_roll, self.train, self.normalize, orog)
+            return reshape_fields(self.files[year_idx][(local_idx-self.dt*self.n_history):(local_idx+1):self.dt, self.in_channels], 'inp', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y,self.params, y_roll, self.train, self.in_means, self.in_stds, self.normalize, orog, self.add_noise), \
+                    reshape_fields(self.files[year_idx][local_idx + step, self.out_channels], 'tar', self.crop_size_x, self.crop_size_y, rnd_x, rnd_y, self.params, y_roll, self.train, self.out_means, self.out_stds, self.normalize, orog)
 
 
 

--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -78,7 +78,7 @@ class PeriodicPad2d(nn.Module):
         out = F.pad(out, (0, 0, self.pad_width, self.pad_width), mode="constant", value=0) 
         return out
 
-def reshape_fields(img, inp_or_tar, crop_size_x, crop_size_y,rnd_x, rnd_y, params, y_roll, train, normalize=True, orog=None, add_noise=False):
+def reshape_fields(img, inp_or_tar, crop_size_x, crop_size_y,rnd_x, rnd_y, params, y_roll, train, means, stds, normalize=True, orog=None, add_noise=False):
     #Takes in np array of size (n_history+1, c, h, w) and returns torch tensor of size ((n_channels*(n_history+1), crop_size_x, crop_size_y)
 
     if len(np.shape(img)) ==3:
@@ -90,9 +90,6 @@ def reshape_fields(img, inp_or_tar, crop_size_x, crop_size_y,rnd_x, rnd_y, param
     img_shape_x = np.shape(img)[-2]
     img_shape_y = np.shape(img)[-1]
     n_channels = np.shape(img)[1] #this will either be N_in_channels or N_out_channels
-    channels = params.in_channels if inp_or_tar =='inp' else params.out_channels
-    means = np.load(params.global_means_path)[:, channels]
-    stds = np.load(params.global_stds_path)[:, channels]
     if crop_size_x == None:
         crop_size_x = img_shape_x
     if crop_size_y == None:


### PR DESCRIPTION
Makes this function more modular and easier to test. Maybe more efficient with less np.load calls?