### PR TITLE
Enable inference for FV3GFS data

### DIFF
--- a/data_process/get_stats_fv3gfs.py
+++ b/data_process/get_stats_fv3gfs.py
@@ -10,9 +10,12 @@ ds = xr.open_mfdataset(os.path.join(DATA_PATH, '*.nc'), chunks=None)
 with xr.set_options(keep_attrs=True):
     global_means = ds.mean(dim=['time', 'grid_xt', 'grid_yt'])
     global_stds = ds.std(dim=['time', 'grid_xt', 'grid_yt'])
+    time_means = ds.mean(dim='time')
 
 global_means.to_netcdf(os.path.join(OUTPUT_PATH, 'fv3gfs-mean.nc'))
 global_stds.to_netcdf(os.path.join(OUTPUT_PATH, 'fv3gfs-stddev.nc'))
+time_means.to_netcdf(os.path.join(OUTPUT_PATH, 'fv3gfs-time-mean.nc'))
 
-print("means: ", global_means)
+print("global means: ", global_means)
 print("stds: ", global_stds)
+print("time means: ", time_means)

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -150,7 +150,7 @@ def setup(params):
     # load the validation data
     if params.log_to_screen:
         logging.info('Loading inference data')
-    valid_data_full = valid_dataset.data_sample
+    valid_data_full = valid_dataset.data_array
 
     return valid_data_full, model
 

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -133,8 +133,9 @@ def setup(params):
     else:
       params['N_in_channels'] = n_in_channels
     params['N_out_channels'] = n_out_channels
-    params.means = np.load(params.global_means_path)[0, out_channels] # needed to standardize wind data
-    params.stds = np.load(params.global_stds_path)[0, out_channels]
+    params.means = valid_dataset.out_means[0] # needed to standardize wind data
+    params.stds = valid_dataset.out_stds[0]
+    params.time_means = valid_dataset.out_time_means[0]
 
     # load the model
     if params.nettype == 'afno':
@@ -147,15 +148,9 @@ def setup(params):
     model = model.to(device)
 
     # load the validation data
-    files_paths = glob.glob(params.inf_data_path + "/*.h5")
-    files_paths.sort()
-    # which year
-    yr = 0
     if params.log_to_screen:
         logging.info('Loading inference data')
-        logging.info('Inference data from {}'.format(files_paths[yr]))
-
-    valid_data_full = h5py.File(files_paths[yr], 'r')['fields']
+    valid_data_full = valid_dataset.data_sample
 
     return valid_data_full, model
 
@@ -176,6 +171,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     out_names = [CHANNEL_NAMES[c] for c in out_channels]
     means = params.means
     stds = params.stds
+    time_means = params.time_means
 
     #initialize memory for image sequences and RMSE/ACC
     valid_loss = torch.zeros((prediction_length, n_out_channels)).to(device, dtype=torch.float)
@@ -199,14 +195,18 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     if params.masked_acc:
       maskarray = torch.as_tensor(np.load(params.maskpath)[0:720]).to(device, dtype=torch.float)
 
-    valid_data = valid_data_full[ic:(ic+prediction_length*dt+n_history*dt):dt, in_channels, 0:720] #extract valid data from first year
+    valid_data = valid_data_full[ic:(ic+prediction_length*dt+n_history*dt):dt, in_channels] #extract valid data from first year
+    if valid_data.shape[2] > 720:
+       # might be necessary for ERA5 data
+       valid_data = valid_data[:, :, 0:720]
+       
     # standardize
     valid_data = (valid_data - means)/stds
     valid_data = torch.as_tensor(valid_data).to(device, dtype=torch.float)
 
     #load time means
     if not params.use_daily_climatology:
-      m = torch.as_tensor((np.load(params.time_means_path)[0][out_channels] - means)/stds)[:, 0:img_shape_x] # climatology
+      m = torch.as_tensor((time_means[out_channels] - means)/stds)[:, 0:img_shape_x]
       m = torch.unsqueeze(m, 0)
     else:
       # use daily clim like weyn et al. (different from rasp)

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -97,23 +97,26 @@ class FV3GFSDataset(Dataset):
         logging.info(f"Following variables are available: {list(self.ds.variables)}.")
 
     def _load_stats_data(self):
-        logging.info(f"Opening mean stats data at {self.params.global_means_path}")
-        means_ds = netCDF4.Dataset(self.params.global_means_path)
-        means_ds.set_auto_mask(False)
-        self.in_means = np.array([means_ds.variables[c][:] for c in self.in_names])
-        self.out_means = np.array([means_ds.variables[c][:] for c in self.out_names])
-        self.in_means = self.in_means.reshape((1, self.n_in_channels, 1, 1))
-        self.out_means = self.out_means.reshape((1, self.n_out_channels, 1, 1))
-        means_ds.close()
+        logging.info(f"Opening global mean stats data at {self.params.global_means_path}")
+        in_, out_ = load_arrays_from_netcdf(self.params.global_means_path, self.in_names, self.out_names)
+        self.in_means = in_.reshape((1, self.n_in_channels, 1, 1))
+        self.out_means = out_.reshape((1, self.n_out_channels, 1, 1))
 
         logging.info(f"Opening stddev stats data at {self.params.global_stds_path}")
-        stddev_ds = netCDF4.Dataset(self.params.global_stds_path)
-        stddev_ds.set_auto_mask(False)
-        self.in_stds = np.array([stddev_ds.variables[c][:] for c in self.in_names])
-        self.out_stds = np.array([stddev_ds.variables[c][:] for c in self.out_names])
-        self.in_stds = self.in_stds.reshape((1, self.n_in_channels, 1, 1))
-        self.out_stds = self.out_stds.reshape((1, self.n_out_channels, 1, 1))
-        stddev_ds.close()
+        in_, out_ = load_arrays_from_netcdf(self.params.global_stds_path, self.in_names, self.out_names)
+        self.in_stds = in_.reshape((1, self.n_in_channels, 1, 1))
+        self.out_stds = out_.reshape((1, self.n_out_channels, 1, 1))
+
+        # just used for multistep validation
+        logging.info(f"Opening time mean stats data at {self.params.time_means_path}")
+        in_, out_ = load_arrays_from_netcdf(self.params.time_means_path, self.in_names, self.out_names)
+        self.out_time_means = np.expand_dims(out_, 0)
+
+    @property
+    def data_sample(self):
+        fv3gfs_names = [FV3GFS_NAMES[v] for v in CHANNEL_NAMES]
+        arrays = [np.expand_dims(self.ds.variables[v][:], 0) for v in fv3gfs_names]
+        return np.concatenate(arrays, axis=0)
 
     def __len__(self):
         return self.n_samples_total
@@ -157,3 +160,14 @@ class FV3GFSDataset(Dataset):
             self.orography,
         )
         return in_tensor, out_tensor
+
+def load_arrays_from_netcdf(path, in_names, out_names):
+    ds = netCDF4.Dataset(path)
+    ds.set_auto_mask(False)
+    in_array = np.array([ds.variables[c][:] for c in in_names])
+    out_array = np.array([ds.variables[c][:] for c in out_names])
+    ds.close()
+    return in_array, out_array
+    self.in_means = self.in_means.reshape((1, self.n_in_channels, 1, 1))
+    self.out_means = self.out_means.reshape((1, self.n_out_channels, 1, 1))
+    means_ds.close()

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -168,6 +168,3 @@ def load_arrays_from_netcdf(path, in_names, out_names):
     out_array = np.array([ds.variables[c][:] for c in out_names])
     ds.close()
     return in_array, out_array
-    self.in_means = self.in_means.reshape((1, self.n_in_channels, 1, 1))
-    self.out_means = self.out_means.reshape((1, self.n_out_channels, 1, 1))
-    means_ds.close()

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -115,8 +115,8 @@ class FV3GFSDataset(Dataset):
     @property
     def data_sample(self):
         fv3gfs_names = [FV3GFS_NAMES[v] for v in CHANNEL_NAMES]
-        arrays = [np.expand_dims(self.ds.variables[v][:], 0) for v in fv3gfs_names]
-        return np.concatenate(arrays, axis=0)
+        arrays = [np.expand_dims(self.ds.variables[v][:], 1) for v in fv3gfs_names]
+        return np.concatenate(arrays, axis=1)
 
     def __len__(self):
         return self.n_samples_total

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -113,7 +113,7 @@ class FV3GFSDataset(Dataset):
         self.out_time_means = np.expand_dims(out_, 0)
 
     @property
-    def data_sample(self):
+    def data_array(self):
         fv3gfs_names = [FV3GFS_NAMES[v] for v in CHANNEL_NAMES]
         arrays = [np.expand_dims(self.ds.variables[v][:], 1) for v in fv3gfs_names]
         return np.concatenate(arrays, axis=1)

--- a/utils/data_loader_multifiles.py
+++ b/utils/data_loader_multifiles.py
@@ -164,7 +164,7 @@ class GetDataset(Dataset):
 
 
   @property
-  def data_sample(self):
+  def data_array(self):
     # returns array of first file of data
     logging.info(f'Loading data from {self.files_paths[0]}')
     _file = h5py.File(self.files_paths[0], 'r')

--- a/utils/data_loader_multifiles.py
+++ b/utils/data_loader_multifiles.py
@@ -118,6 +118,7 @@ class GetDataset(Dataset):
     self.in_stds = np.load(params.global_stds_path)[:, self.in_channels]
     self.out_means = np.load(params.global_means_path)[:, self.out_channels]
     self.out_stds = np.load(params.global_stds_path)[:, self.out_channels]
+    self.out_time_means = np.load(params.time_means_path)
 
     if self.precip:
         path = params.precip+'/train' if train else params.precip+'/test'
@@ -160,6 +161,14 @@ class GetDataset(Dataset):
       self.orography_field = _orog_file['orog']
     if self.precip:
       self.precip_files[year_idx] = h5py.File(self.precip_paths[year_idx], 'r')['tp']
+
+
+  @property
+  def data_sample(self):
+    # returns array of first file of data
+    logging.info(f'Loading data from {self.files_paths[0]}')
+    _file = h5py.File(self.files_paths[0], 'r')
+    return _file['fields']
     
   
   def __len__(self):


### PR DESCRIPTION
Although I implemented a data loader for FV3GFS in #4, there were some further changes required to allow using the `inference.py` script with FV3GFS data (mostly removing IO from within the `setup` function). It also required a new time-mean, and lat/lon dependent, statistics file to be calculated. So the script to compute FV3GFS statistics was updated also.