### PR TITLE
implement summary metrics in inference routine

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -325,6 +325,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     # inspect snapshot times at 5-days, 10-days.
     # N.B. the predictions are 1-indexed, i.e. index 0 is the first prediction.
     snapshot_timesteps = [(24 // 6 * k - 1, f"{k}-days") for k in [5, 10]]
+
     # TODO(gideond) move these names to a higher-level to avoid potential bugs
     metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']
     # All metrics has shape [metric_type, timestep, channel]
@@ -334,7 +335,10 @@ def autoregressive_inference(params, ic, valid_data_full, model):
         for j, time_name in snapshot_timesteps:
           for k in range(len(out_names)):
             name = f'{metric_names[i]}/ic{ic}/{out_names[k]}/{time_name}'
-            wandb.log({name: all_metrics[i, j, k]})
+            try:
+              wandb.log({name: all_metrics[i, j, k]})
+            except IndexError:
+               logging.error(f"Failed to log {name}")
 
     seq_real = seq_real.cpu().numpy()
     seq_pred = seq_pred.cpu().numpy()

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -325,6 +325,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     # inspect snapshot times at 5-days, 10-days.
     # N.B. the predictions are 1-indexed, i.e. index 0 is the first prediction.
     snapshot_timesteps = [(24 // 6 * k - 1, f"{k}-days") for k in [5, 10]]
+    # TODO(gideond) move these names to a higher-level to avoid potential bugs
     metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']
     # All metrics has shape [metric_type, timestep, channel]
     all_metrics = [valid_loss, acc, global_mean_pred, global_mean_target, gradient_magnitude_pred, gradient_magnitude_target]

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -173,6 +173,18 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     stds = params.stds
     time_means = params.time_means
 
+    # Consider the default case to be when this function is called outside of
+    # main. In this case, we assume that the caller is train.py and therefore we
+    # do not want to log the metrics for each time-step unroll. Instead, we want
+    # to log aggegrated metrics for a *single* initial condition (ic) aggregated
+    # over time.
+    if 'is_log_time_series_metrics_to_wandb' not in params:
+      # the YParams object doesn't support params.get(k, 'default') 
+      params['is_log_time_series_metrics_to_wandb'] = False
+    
+    if 'is_log_aggregated_metrics_to_wandb' not in params:
+        params['is_log_aggregated_metrics_to_wandb'] = True  # I ran the inference code for True and False (gideond).
+
     #initialize memory for image sequences and RMSE/ACC
     valid_loss = torch.zeros((prediction_length, n_out_channels)).to(device, dtype=torch.float)
     acc = torch.zeros((prediction_length, n_out_channels)).to(device, dtype=torch.float)
@@ -311,17 +323,26 @@ def autoregressive_inference(params, ic, valid_data_full, model):
             f'global_mean_gradient_magnitude_target/ic{ic}/channel{c}-{name}':
             gradient_magnitude_target[i, c] for c, name in enumerate(out_names)
           }
-          wandb.log(
-            {
-              **rmse_metrics,
-              **acc_metrics,
-              **mean_pred_metrics,
-              **mean_target_metrics,
-              **grad_mag_pred_metrics,
-              **grad_mag_target_metrics
-            }
-          )
+          if params.is_log_time_series_metrics_to_wandb:
+            wandb.log(
+              {
+                **rmse_metrics,
+                **acc_metrics,
+                **mean_pred_metrics,
+                **mean_target_metrics,
+                **grad_mag_pred_metrics,
+                **grad_mag_target_metrics
+              }
+            )
               
+    if params.is_log_aggregated_metrics_to_wandb:
+      # each metric is [time x channel]
+      all_metrics = [valid_loss, acc, global_mean_pred, global_mean_target, gradient_magnitude_pred, gradient_magnitude_target]
+      time_avg_metrics = [m.mean(axis=0) for m in all_metrics]
+      metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']
+      for m, n in zip(time_avg_metrics, metric_names):
+        for c, name in enumerate(out_names):
+          wandb.log({f'{n}/ic{ic}/channel{c}-{name}': m[c]})
 
     seq_real = seq_real.cpu().numpy()
     seq_pred = seq_pred.cpu().numpy()
@@ -358,6 +379,12 @@ if __name__ == '__main__':
     params['interp'] = args.interp
     params['use_daily_climatology'] = args.use_daily_climatology
     params['global_batch_size'] = params.batch_size
+
+    # When running main, we want to log unaggegrated time series metrics to wandb.
+    # See `autoregressive_inference` config setup for more info.
+    # TODO(gideond) might be useful to make this an actual cmdline arg.
+    params['is_log_time_series_metrics_to_wandb'] = True
+    params['is_log_aggregated_metrics_to_wandb'] = False
 
     device = torch.cuda.current_device() if torch.cuda.is_available() else 'cpu'
     if device != 'cpu':
@@ -421,7 +448,13 @@ if __name__ == '__main__':
                 hour_of_day = date_obj.timetuple().tm_hour
                 hours_since_jan_01_epoch = 24*day_of_year + hour_of_day
                 ics.append(int(hours_since_jan_01_epoch/6))
-        n_ics = len(ics)
+
+    if params.is_log_aggregated_metrics_to_wandb:
+      logging.info("Logging aggregated metrics to wandb => using only first initial condition.")
+      ics = [ics[0]]
+      n_ics = 1
+    else:
+      n_ics = len(ics)
 
     logging.info("Inference for {} initial conditions".format(n_ics))
     try:

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -438,6 +438,7 @@ if __name__ == '__main__':
                 hour_of_day = date_obj.timetuple().tm_hour
                 hours_since_jan_01_epoch = 24*day_of_year + hour_of_day
                 ics.append(int(hours_since_jan_01_epoch/6))
+        n_ics = len(ics)
 
     logging.info("Inference for {} initial conditions".format(n_ics))
     try:

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -322,22 +322,24 @@ def autoregressive_inference(params, ic, valid_data_full, model):
             }
           )
               
-    # inspect snapshot times at 5-days and 10-days.
-    snapshot_timesteps = [(24 // 6 * k, f"{k}-days") for k in [5, 10]]
 
-    # TODO(gideond) move these names to a higher-level to avoid potential bugs
-    metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']
-    # All metrics has shape [metric_type, timestep, channel]
-    all_metrics = [valid_loss, acc, global_mean_pred, global_mean_target, gradient_magnitude_pred, gradient_magnitude_target]
-    all_metrics = np.array([m.cpu().numpy() for m in all_metrics])
-    for i in range(len(metric_names)):
-        for j, time_name in snapshot_timesteps:
-          for k in range(len(out_names)):
-            name = f'{metric_names[i]}_{time_name}/ic{ic}/channel{k}-{out_names[k]}'
-            try:
-              wandb.log({name: all_metrics[i, j, k]})
-            except IndexError:
-               logging.error(f"Failed to log {name}")
+    if params.log_to_wandb:
+      # inspect snapshot times at 5-days and 10-days.
+      snapshot_timesteps = [(24 // 6 * k, f"{k}-days") for k in [5, 10]]
+
+      # TODO(gideond) move these names to a higher-level to avoid potential bugs
+      metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']
+      # All metrics has shape [metric_type, timestep, channel]
+      all_metrics = [valid_loss, acc, global_mean_pred, global_mean_target, gradient_magnitude_pred, gradient_magnitude_target]
+      all_metrics = np.array([m.cpu().numpy() for m in all_metrics])
+      for i in range(len(metric_names)):
+          for j, time_name in snapshot_timesteps:
+            for k in range(len(out_names)):
+              name = f'{metric_names[i]}_{time_name}/ic{ic}/channel{k}-{out_names[k]}'
+              try:
+                wandb.log({name: all_metrics[i, j, k]})
+              except IndexError:
+                logging.error(f"Failed to log {name}")
 
     seq_real = seq_real.cpu().numpy()
     seq_pred = seq_pred.cpu().numpy()

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -334,7 +334,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     for i in range(len(metric_names)):
         for j, time_name in snapshot_timesteps:
           for k in range(len(out_names)):
-            name = f'{metric_names[i]}/ic{ic}/{out_names[k]}/{time_name}'
+            name = f'{metric_names[i]}_{time_name}/ic{ic}/channel{k}-{out_names[k]}'
             try:
               wandb.log({name: all_metrics[i, j, k]})
             except IndexError:

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -324,7 +324,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
               
     # inspect snapshot times at 5-days, 10-days.
     # N.B. the predictions are 1-indexed, i.e. index 0 is the first prediction.
-    snapshot_timesteps = [(24 // 6 * k - 1, f"{k}-days") for k in [5, 10]]
+    snapshot_timesteps = [(24 // 6 * k, f"{k}-days") for k in [5, 10]]
 
     # TODO(gideond) move these names to a higher-level to avoid potential bugs
     metric_names = ['rmse', 'acc', 'global_mean_prediction', 'global_mean_target', 'global_mean_gradient_magnitude_prediction', 'global_mean_gradient_magnitude_target']

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -322,8 +322,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
             }
           )
               
-    # inspect snapshot times at 5-days, 10-days.
-    # N.B. the predictions are 1-indexed, i.e. index 0 is the first prediction.
+    # inspect snapshot times at 5-days and 10-days.
     snapshot_timesteps = [(24 // 6 * k, f"{k}-days") for k in [5, 10]]
 
     # TODO(gideond) move these names to a higher-level to avoid potential bugs

--- a/train.py
+++ b/train.py
@@ -77,7 +77,6 @@ import json
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap as ruamelDict
 
-
 class Trainer():
   def count_parameters(self):
     return sum(p.numel() for p in self.model.parameters() if p.requires_grad)
@@ -451,7 +450,7 @@ class Trainer():
          f'valid_gradient_magnitude_percent_diff/channel{c}-{name}': valid_gradient_magnitude_diff_cpu[c]
          for c, name in enumerate(self.valid_dataset.out_names)
       }
-
+    
     if self.params.log_to_wandb:
       if self.precip:
         fig = vis_precip(fields)

--- a/train.py
+++ b/train.py
@@ -77,6 +77,7 @@ import json
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap as ruamelDict
 
+
 class Trainer():
   def count_parameters(self):
     return sum(p.numel() for p in self.model.parameters() if p.requires_grad)
@@ -450,7 +451,7 @@ class Trainer():
          f'valid_gradient_magnitude_percent_diff/channel{c}-{name}': valid_gradient_magnitude_diff_cpu[c]
          for c, name in enumerate(self.valid_dataset.out_names)
       }
-    
+
     if self.params.log_to_wandb:
       if self.precip:
         fig = vis_precip(fields)


### PR DESCRIPTION
1/2 steps towards getting inference into the training loop.

This change implements an option to switch between:

1) running inference on all time steps and initial conditions and saving all the results to wandb, and
2) running inference on only the first initial condition, taking the mean value over time, and logging the result (over what is currently 20 variables) to wandb