### PR TITLE
Don't throw away train_logs return item

### DIFF
--- a/train.py
+++ b/train.py
@@ -206,7 +206,7 @@ class Trainer():
 #        self.valid_sampler.set_epoch(epoch)
 
       start = time.time()
-      _, _, _ = self.train_one_epoch()
+      _, _, train_logs = self.train_one_epoch()
       valid_time, valid_logs = self.validate_one_epoch()
       inference_logs = self.inference_one_epoch()
 


### PR DESCRIPTION
#14 introduced a bug by not keeping the `train_logs` output from `self.train_one_epoch()`. This fix resolves that issue. This bug would have been caught by an integration test of `Trainer.train` (see #16).

This was the traceback I got when training a model with f171980:

```
2023-03-23T00:58:04.513844953Z Traceback (most recent call last):
2023-03-23T00:58:04.513960292Z   File "/opt/ERA5_wind/train.py", line 669, in <module>
2023-03-23T00:58:04.513967162Z     trainer.train()
2023-03-23T00:58:04.514009792Z   File "/opt/ERA5_wind/train.py", line 236, in train
2023-03-23T00:58:04.514014772Z     logging.info('Train loss: {}. Valid loss: {}'.format(train_logs['loss'], valid_logs['valid_loss']))
2023-03-23T00:58:04.514172021Z NameError: name 'train_logs' is not defined
```