### PR TITLE
Allow specifying inputs/outputs by name

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -123,10 +123,10 @@ def setup(params):
     if params.log_to_screen:
         logging.info('Loading trained model checkpoint from {}'.format(params['best_checkpoint_path']))
 
-    in_channels = np.array(params.in_channels)
-    out_channels = np.array(params.out_channels)
-    n_in_channels = len(in_channels)
-    n_out_channels = len(out_channels)
+    #in_channels = np.array(params.in_channels)
+    #out_channels = np.array(params.out_channels)
+    n_in_channels = params.N_in_channels
+    n_out_channels = params.N_out_channels
     
     if params["orography"]:
       params['N_in_channels'] = n_in_channels + 1
@@ -166,11 +166,11 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     n_history = params.n_history
     img_shape_x = params.img_shape_x
     img_shape_y = params.img_shape_y
-    in_channels = np.array(params.in_channels)
-    out_channels = np.array(params.out_channels)
-    n_in_channels = len(in_channels)
-    n_out_channels = len(out_channels)
-    out_names = [CHANNEL_NAMES[c] for c in out_channels]
+    #in_channels = np.array(params.in_channels)
+    #out_channels = np.array(params.out_channels)
+    n_in_channels = params.N_in_channels
+    n_out_channels = params.N_out_channels
+    out_names = params.out_names
     means = params.means
     stds = params.stds
     time_means = params.time_means
@@ -197,7 +197,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     if params.masked_acc:
       maskarray = torch.as_tensor(np.load(params.maskpath)[0:720]).to(device, dtype=torch.float)
 
-    valid_data = valid_data_full[ic:(ic+prediction_length*dt+n_history*dt):dt, in_channels] #extract valid data from first year
+    valid_data = valid_data_full[ic:(ic+prediction_length*dt+n_history*dt):dt] #extract valid data from first year
     if valid_data.shape[2] > 720:
        # might be necessary for ERA5 data
        valid_data = valid_data[:, :, 0:720]
@@ -208,7 +208,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
 
     #load time means
     if not params.use_daily_climatology:
-      m = torch.as_tensor((time_means[out_channels] - means)/stds)[:, 0:img_shape_x]
+      m = torch.as_tensor((time_means - means)/stds)[:, 0:img_shape_x]
       m = torch.unsqueeze(m, 0)
     else:
       # use daily clim like weyn et al. (different from rasp)

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -123,10 +123,10 @@ def setup(params):
     if params.log_to_screen:
         logging.info('Loading trained model checkpoint from {}'.format(params['best_checkpoint_path']))
 
-    #in_channels = np.array(params.in_channels)
-    #out_channels = np.array(params.out_channels)
-    n_in_channels = params.N_in_channels
-    n_out_channels = params.N_out_channels
+    n_in_channels = valid_dataset.n_in_channels
+    n_out_channels = valid_dataset.n_out_channels
+    params.in_names = valid_dataset.in_names
+    params.out_names = valid_dataset.out_names
     
     if params["orography"]:
       params['N_in_channels'] = n_in_channels + 1
@@ -166,8 +166,6 @@ def autoregressive_inference(params, ic, valid_data_full, model):
     n_history = params.n_history
     img_shape_x = params.img_shape_x
     img_shape_y = params.img_shape_y
-    #in_channels = np.array(params.in_channels)
-    #out_channels = np.array(params.out_channels)
     n_in_channels = params.N_in_channels
     n_out_channels = params.N_out_channels
     out_names = params.out_names
@@ -215,7 +213,7 @@ def autoregressive_inference(params, ic, valid_data_full, model):
       dc_path = params.dc_path
       with h5py.File(dc_path, 'r') as f:
         dc = f['time_means_daily'][ic:ic+prediction_length*dt:dt] # 1460,21,721,1440
-      m = torch.as_tensor((dc[:,out_channels,0:img_shape_x,:] - means)/stds) 
+      m = torch.as_tensor((dc[:,params.out_channels,0:img_shape_x,:] - means)/stds) 
 
     m = m.to(device, dtype=torch.float)
     if params.interp > 0:

--- a/networks/afnonet.py
+++ b/networks/afnonet.py
@@ -176,7 +176,7 @@ class AFNONet(nn.Module):
             patch_size=(16, 16),
             in_chans=2,
             out_chans=2,
-            embed_dim=768,
+            embed_dim=48,
             depth=12,
             mlp_ratio=4.,
             drop_rate=0.,

--- a/networks/afnonet.py
+++ b/networks/afnonet.py
@@ -176,7 +176,7 @@ class AFNONet(nn.Module):
             patch_size=(16, 16),
             in_chans=2,
             out_chans=2,
-            embed_dim=48,
+            embed_dim=768,
             depth=12,
             mlp_ratio=4.,
             drop_rate=0.,

--- a/train.py
+++ b/train.py
@@ -102,6 +102,12 @@ class Trainer():
     params.crop_size_y = self.valid_dataset.crop_size_y
     params.img_shape_x = self.valid_dataset.img_shape_x
     params.img_shape_y = self.valid_dataset.img_shape_y
+    params.N_in_channels = self.train_dataset.n_in_channels
+    if params.orography:
+      params.N_in_channels += 1
+    params.N_out_channels = self.train_dataset.n_out_channels
+    params.in_names = self.train_dataset.in_names
+    params.out_names = self.train_dataset.out_names
 
     # precip models
     self.precip = True if "precip" in params else False
@@ -647,15 +653,6 @@ if __name__ == '__main__':
 
   params['log_to_wandb'] = (world_rank==0) and params['log_to_wandb']
   params['log_to_screen'] = (world_rank==0) and params['log_to_screen']
-
-  params['in_channels'] = np.array(params['in_channels'])
-  params['out_channels'] = np.array(params['out_channels'])
-  if params.orography:
-    params['N_in_channels'] = len(params['in_channels']) +1
-  else:
-    params['N_in_channels'] = len(params['in_channels'])
-
-  params['N_out_channels'] = len(params['out_channels'])
 
   if world_rank == 0:
     hparams = ruamelDict()

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -37,17 +37,12 @@ class FV3GFSDataset(Dataset):
     def __init__(self, params: MutableMapping, path: str, train: bool):
         self.params = params
         self._check_for_not_implemented_features()
+        self._resolve_channels_and_names()
         self.path = path
         self.full_path = os.path.join(path, "*.nc")
         self.train = train
         self.dt = params.dt
         self.n_history = params.n_history
-        self.in_channels = np.array(params.in_channels)
-        self.out_channels = np.array(params.out_channels)
-        self.n_in_channels = len(self.in_channels)
-        self.n_out_channels = len(self.out_channels)
-        self.in_names = [FV3GFS_NAMES[CHANNEL_NAMES[c]] for c in self.in_channels]
-        self.out_names = [FV3GFS_NAMES[CHANNEL_NAMES[c]] for c in self.out_channels]
         self.crop_size_x = params.crop_size_x
         self.crop_size_y = params.crop_size_y
         self.roll = params.roll
@@ -82,6 +77,26 @@ class FV3GFSDataset(Dataset):
         if self.params.add_grid:
             raise NotImplementedError("add_grid not implemented for FV3GFSDataset")
 
+    def _resolve_channels_and_names(self):
+        if "in_channels" in self.params and "in_names" in self.params:
+            raise ValueError("Cannot specify both 'in_channels' and 'in_names' params.")
+        if "out_channels" in self.params and "out_names" in self.params:
+            raise ValueError("Cannot specify both 'out_channels' and 'out_names' params.")
+
+        if "in_channels" in self.params:
+            self.in_names = [FV3GFS_NAMES[CHANNEL_NAMES[c]] for c in self.params.in_channels]
+        else:
+            self.in_names = self.params.in_names
+
+        if "out_channels" in self.params:
+            self.out_names = [FV3GFS_NAMES[CHANNEL_NAMES[c]] for c in self.params.out_channels]
+        else:
+            self.out_names = self.params.out_names
+    
+        self.n_in_channels = len(self.in_names)
+        self.n_out_channels = len(self.out_names)
+       
+        
     def _get_files_stats(self):
         logging.info(f"Opening data at {self.full_path}")
         self.ds = netCDF4.MFDataset(self.full_path)

--- a/utils/data_loader_fv3gfs.py
+++ b/utils/data_loader_fv3gfs.py
@@ -129,8 +129,7 @@ class FV3GFSDataset(Dataset):
 
     @property
     def data_array(self):
-        fv3gfs_names = [FV3GFS_NAMES[v] for v in CHANNEL_NAMES]
-        arrays = [np.expand_dims(self.ds.variables[v][:], 1) for v in fv3gfs_names]
+        arrays = [np.expand_dims(self.ds.variables[v][:], 1) for v in self.in_names]
         return np.flip(np.concatenate(arrays, axis=1), axis=-2).copy()
 
     def __len__(self):

--- a/utils/data_loader_multifiles.py
+++ b/utils/data_loader_multifiles.py
@@ -120,7 +120,7 @@ class GetDataset(Dataset):
     self.in_stds = np.load(params.global_stds_path)[:, self.in_channels]
     self.out_means = np.load(params.global_means_path)[:, self.out_channels]
     self.out_stds = np.load(params.global_stds_path)[:, self.out_channels]
-    self.out_time_means = np.load(params.time_means_path)
+    self.out_time_means = np.load(params.time_means_path)[:, self.out_channels]
 
     if self.precip:
         path = params.precip+'/train' if train else params.precip+'/test'
@@ -167,10 +167,10 @@ class GetDataset(Dataset):
 
   @property
   def data_array(self):
-    # returns array of first file of data
+    # returns array of first file of data, for in_channels only
     logging.info(f'Loading data from {self.files_paths[0]}')
     _file = h5py.File(self.files_paths[0], 'r')
-    return _file['fields']
+    return _file['fields'][:, self.in_channels]
     
   
   def __len__(self):

--- a/utils/data_loader_multifiles.py
+++ b/utils/data_loader_multifiles.py
@@ -167,7 +167,7 @@ class GetDataset(Dataset):
 
   @property
   def data_array(self):
-    # returns array of first file of data, for in_channels only
+"""Returns array of first file of data for `self.in_channels` only"""
     logging.info(f'Loading data from {self.files_paths[0]}')
     _file = h5py.File(self.files_paths[0], 'r')
     return _file['fields'][:, self.in_channels]

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -39,8 +39,8 @@ class DotDict:
 
 def test_FV3GFSDataset_init():
     dataset = FV3GFSDataset(DotDict(TEST_PARAMS), TEST_PATH, True)
-    dataset.in_names == ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
-    dataset.out_names == ["UGRD10m", "VGRD10m", "TMP850", "TCWV", "Z500"]
+    assert dataset.in_names == ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
+    assert dataset.out_names == ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
 
 
 def test_FV3GFSDataset_len():

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -35,6 +35,10 @@ TEST_PARAMS_SPECIFY_BY_NAME["out_names"] = TEST_OUT_NAMES
 
 
 class DotDict:
+"""Overrides the dot operator for accessing fields to be dict lookup.
+
+e.g. `dotdict.key == dotdict['key']  == dotdict.items['key']`
+"""
     def __init__(self, items):
         self.items = items
 

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -7,6 +7,8 @@ import pytest
 
 TEST_PATH = "/traindata"
 TEST_STATS_PATH = "/statsdata"
+TEST_IN_NAMES = ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
+TEST_OUT_NAMES = ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
 TEST_PARAMS = {
     "n_history": 0,
     "crop_size_x": None,
@@ -28,8 +30,8 @@ TEST_PARAMS = {
 TEST_PARAMS_SPECIFY_BY_NAME = copy.copy(TEST_PARAMS)
 TEST_PARAMS_SPECIFY_BY_NAME.pop("in_channels")
 TEST_PARAMS_SPECIFY_BY_NAME.pop("out_channels")
-TEST_PARAMS_SPECIFY_BY_NAME["in_names"] = ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
-TEST_PARAMS_SPECIFY_BY_NAME["out_names"] = ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
+TEST_PARAMS_SPECIFY_BY_NAME["in_names"] = TEST_IN_NAMES
+TEST_PARAMS_SPECIFY_BY_NAME["out_names"] = TEST_OUT_NAMES
 
 
 class DotDict:
@@ -49,8 +51,8 @@ class DotDict:
 @pytest.mark.parametrize("params", [TEST_PARAMS, TEST_PARAMS_SPECIFY_BY_NAME])
 def test_FV3GFSDataset_init(params):
     dataset = FV3GFSDataset(DotDict(params), TEST_PATH, True)
-    assert dataset.in_names == ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
-    assert dataset.out_names == ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
+    assert dataset.in_names == TEST_IN_NAMES
+    assert dataset.out_names == TEST_OUT_NAMES
 
 
 def test_FV3GFSDataset_len():
@@ -66,3 +68,15 @@ def test_FV3GFSDataset_getitem():
     assert len(output) == 2
     assert output[0].shape == (len(TEST_PARAMS["in_channels"]), 180, 360)
     assert output[1].shape == (len(TEST_PARAMS["out_channels"]), 180, 360)
+
+
+def test_FV3GFSDataset_raises_value_error_if_names_and_channels_both_specified():
+    params = copy.copy(TEST_PARAMS)
+    params['in_names'] = ['foo', 'bar']
+    with pytest.raises(ValueError):
+        FV3GFSDataset(DotDict(params), TEST_PATH, True)
+
+    params = copy.copy(TEST_PARAMS)
+    params['out_names'] = ['foo', 'bar']
+    with pytest.raises(ValueError):
+        FV3GFSDataset(DotDict(params), TEST_PATH, True)

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -1,5 +1,8 @@
+import copy
 import os
+import numpy as np
 from .data_loader_fv3gfs import FV3GFSDataset
+import pytest
 
 TEST_PATH = "/traindata"
 TEST_STATS_PATH = "/statsdata"
@@ -21,6 +24,11 @@ TEST_PARAMS = {
     "global_stds_path": os.path.join(TEST_STATS_PATH, "fv3gfs-stddev.nc"),
     "time_means_path": os.path.join(TEST_STATS_PATH, "fv3gfs-time-mean.nc"),
 }
+TEST_PARAMS_SPECIFY_BY_NAME = copy.copy(TEST_PARAMS)
+TEST_PARAMS_SPECIFY_BY_NAME.pop("in_channels")
+TEST_PARAMS_SPECIFY_BY_NAME.pop("out_channels")
+TEST_PARAMS_SPECIFY_BY_NAME["in_names"] = ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
+TEST_PARAMS_SPECIFY_BY_NAME["out_names"] = ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
 
 
 class DotDict:
@@ -37,8 +45,9 @@ class DotDict:
         return key in self.items
 
 
-def test_FV3GFSDataset_init():
-    dataset = FV3GFSDataset(DotDict(TEST_PARAMS), TEST_PATH, True)
+@pytest.mark.parametrize("params", [TEST_PARAMS, TEST_PARAMS_SPECIFY_BY_NAME])
+def test_FV3GFSDataset_init(params):
+    dataset = FV3GFSDataset(DotDict(params), TEST_PATH, True)
     assert dataset.in_names == ["UGRD10m", "VGRD10m", "PRMSL", "TCWV"]
     assert dataset.out_names == ["UGRD10m", "VGRD10m", "TMP850", "TCWV"]
 

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -1,8 +1,8 @@
 import os
 from .data_loader_fv3gfs import FV3GFSDataset
 
-TEST_PATH = "/Users/oliverwm/scratch/fv3gfs-fourcastnet/fourcastnet_vanilla_1_degree"
-TEST_STATS_PATH = "/Users/oliverwm/scratch/fv3gfs-fourcastnet/stats"
+TEST_PATH = "/traindata"
+TEST_STATS_PATH = "/statsdata"
 TEST_PARAMS = {
     "n_history": 0,
     "crop_size_x": None,
@@ -19,6 +19,7 @@ TEST_PARAMS = {
     "add_grid": False,
     "global_means_path": os.path.join(TEST_STATS_PATH, "fv3gfs-mean.nc"),
     "global_stds_path": os.path.join(TEST_STATS_PATH, "fv3gfs-stddev.nc"),
+    "time_means_path": os.path.join(TEST_STATS_PATH, "fv3gfs-time-mean.nc"),
 }
 
 
@@ -44,7 +45,7 @@ def test_FV3GFSDataset_init():
 
 def test_FV3GFSDataset_len():
     dataset = FV3GFSDataset(DotDict(TEST_PARAMS), TEST_PATH, True)
-    assert len(dataset) == 1459
+    assert len(dataset) == 235
 
 
 def test_FV3GFSDataset_getitem():

--- a/utils/test_fv3gfs_dataset.py
+++ b/utils/test_fv3gfs_dataset.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import numpy as np
+import netCDF4
 from .data_loader_fv3gfs import FV3GFSDataset
 import pytest
 
@@ -54,7 +55,9 @@ def test_FV3GFSDataset_init(params):
 
 def test_FV3GFSDataset_len():
     dataset = FV3GFSDataset(DotDict(TEST_PARAMS), TEST_PATH, True)
-    assert len(dataset) == 235
+    full_path = os.path.join(TEST_PATH, "*.nc")
+    expected_length = len(netCDF4.MFDataset(full_path).variables["time"][:]) - 1
+    assert len(dataset) == expected_length
 
 
 def test_FV3GFSDataset_getitem():


### PR DESCRIPTION
This works for FV3GFS data, which is stored as netCDFs and so has named variables. The feature is necessary to allow training on variables outside the 'standard' set in the provided ERA5 dataset. The feature is implemented in a backwards-compatible way, so user can still specify by channel number. However the channel number is tied to the ERA5 dataset (i.e. the channel numbers always correspond to [this particular list of variables](https://github.com/ai2cm/FourCastNet/blob/2284b291b3f51d6ac08b283231215811e21f4c21/utils/constants.py#L3-L24)).

I manually trained and did inference on both ERA5 and FV3GFS data to verify that this works (in addition to unit tests for FV3GFS data).