### PR TITLE
Use out_names from params/valid dataset

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -508,7 +508,7 @@ if __name__ == '__main__':
     n_out_channels = seq_real[0].shape[1]
     img_shape_x = seq_real[0].shape[2]
     img_shape_y = seq_real[0].shape[3]
-    out_names = [CHANNEL_NAMES[c] for c in params['out_channels']]
+    out_names = params.out_names
 
     #save predictions and loss
     if params.log_to_screen:


### PR DESCRIPTION
We know these names will be correct for either ERA5 data or FV3GFS data. Currently there is a bug if the output variables are specified by name instead of by channel number for FV3GFS.